### PR TITLE
Fix Cargo.toml search path for Bazel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,9 @@ std = ["alloc"]
 # removed at any time.
 __internal_use_only_features_that_work_on_stable = ["alloc", "derive", "simd", "std"]
 
+[build-dependencies]
+walkdir = "2"
+
 [dependencies]
 zerocopy-derive = { version = "=0.8.26", path = "zerocopy-derive", optional = true }
 

--- a/build.rs
+++ b/build.rs
@@ -129,11 +129,11 @@ fn find_cargo_toml() -> String {
 }
 
 fn parse_version_cfgs_from_cargo_toml() -> Vec<VersionCfg> {
-    // When building Tauri apps, we update `rules_rust()` to not change the working directory to the 
-    // Rust app root (i.e. Cargo.toml). Instead we execute from the the sandbox root. This is 
-    // important b/c many of our build tools (i.e. workspace-env) expect to be run from the sandbox 
-    // root.
-    // 
+    // NOTE(paris): When building Tauri apps, we update `rules_rust()` to not change the working 
+    // directory to the Rust app root (i.e. Cargo.toml). Instead we execute from the the sandbox 
+    // root. This is important b/c many of our build tools (i.e. workspace-env) expect to be run from 
+    // the sandbox root.
+    //
     // This means that Cargo.toml may not be available in the current working dir. So we instead
     // search for it in the current directory or any child directory.
     let cargo_toml = fs::read_to_string(find_cargo_toml()).expect("failed to read Cargo.toml 2");

--- a/build.rs
+++ b/build.rs
@@ -138,7 +138,7 @@ fn parse_version_cfgs_from_cargo_toml() -> Vec<VersionCfg> {
     //
     // This means that Cargo.toml may not be available in the current working dir. So we instead
     // search for it in the current directory or any child directory.
-    let cargo_toml = fs::read_to_string(find_cargo_toml()).expect("failed to read Cargo.toml 2");
+    let cargo_toml = fs::read_to_string(find_cargo_toml()).expect("failed to read Cargo.toml");
 
     // Expect a Cargo.toml with the following format:
     //

--- a/build.rs
+++ b/build.rs
@@ -117,6 +117,9 @@ struct VersionCfg {
 
 const ITER_FIRST_NEXT_EXPECT_MSG: &str = "unreachable: a string split cannot produce 0 items";
 
+/// Look for Cargo.toml in the current directory or any child directory.
+///
+/// Returns the path to the file if found, otherwise panics.
 fn find_cargo_toml() -> String {
     if let Some(entry) = WalkDir::new(".")
         .into_iter()

--- a/build.rs
+++ b/build.rs
@@ -120,8 +120,7 @@ const ITER_FIRST_NEXT_EXPECT_MSG: &str = "unreachable: a string split cannot pro
 fn find_cargo_toml() -> String {
     if let Some(entry) = WalkDir::new(".")
         .into_iter()
-        .filter_map(Result::ok)
-        .filter(|e| e.file_name() == "Cargo.toml").next()
+        .filter_map(Result::ok).find(|e| e.file_name() == "Cargo.toml")
     {
         return entry.path().to_string_lossy().to_string();
     }

--- a/build.rs
+++ b/build.rs
@@ -118,10 +118,10 @@ struct VersionCfg {
 const ITER_FIRST_NEXT_EXPECT_MSG: &str = "unreachable: a string split cannot produce 0 items";
 
 fn find_cargo_toml() -> String {
-    for entry in WalkDir::new(".")
+    if let Some(entry) = WalkDir::new(".")
         .into_iter()
         .filter_map(Result::ok)
-        .filter(|e| e.file_name() == "Cargo.toml")
+        .filter(|e| e.file_name() == "Cargo.toml").next()
     {
         return entry.path().to_string_lossy().to_string();
     }


### PR DESCRIPTION
### What
When building Tauri apps, we update `rules_rust()` to not change the working directory to the Rust app root (i.e. Cargo.toml). Instead we execute from the the sandbox root. This is important b/c many of our build tools (i.e. workspace-env) expect to be run from the sandbox root.

But when doing that, we get errors from several places which try to load files assuming they are in the working directory. But they are likely not, instead they are in a child dir of the working directory within the sandbox. So here we update to traverse down the filesystem looking for the requested file.

### Testing
Before this change:
```
--stderr:
thread 'main' panicked at external/tauri-deps__zerocopy-0.8.26/build.rs:120:55:
failed to read Cargo.toml: Os { code: 2, kind: NotFound, message: "No such file or directory" }
stack backtrace:
   0:        0x10006e938 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::habbf9c4f641febb1
   1:        0x1000b0234 - core::fmt::write::ha36a8060c13608ea
   2:        0x100063448 - std::io::Write::write_fmt::h431832c8ebcc85c9
   3:        0x100071000 - std::panicking::default_hook::{{closure}}::h4aa1f60327dfff6a
   4:        0x100070bb0 - std::panicking::default_hook::h4ebc6eb4ae179807
   5:        0x100071c1c - std::panicking::rust_panic_with_hook::h6a84efe4dcab239c
   6:        0x100071648 - std::panicking::begin_panic_handler::{{closure}}::h5eef292190467fef
   7:        0x10006edfc - std::sys::backtrace::__rust_end_short_backtrace::hd7e7925203f20af9
   8:        0x100071310 - _rust_begin_unwind
   9:        0x1000ac9dc - core::panicking::panic_fmt::h410d3f147658259b
  10:        0x1000ace7c - core::result::unwrap_failed::h974e6b19638d9dc8
  11:        0x100036d28 - build_script_build::main::hb40b5b63f6ea92a9
  12:        0x100037104 - std::sys::backtrace::__rust_begin_short_backtrace::he90ed75a0f0964f4
  13:        0x1000370ec - std::rt::lang_start::{{closure}}::h7d0e1907eef4e316
  14:        0x100056488 - std::rt::lang_start_internal::h9e88109c8deb8787
  15:        0x1000370d0 - _main
```

After this change we can build.